### PR TITLE
Context might not be set correctly when updating from old version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": {
         "name": "Thomas Bowman Mørch"
     },
-    "version": "4.0.0",
+    "version": "4.0.1",
     "scripts": {
         "postcoverage": "nyc check-coverage --functions 50 --branches 50 --statements 90",
         "build": "mkdir -p dist/nodes/ && cp -ar src/nodes/*.html dist/nodes/ && tsc ",

--- a/src/lib/nodered-storage.spec.ts
+++ b/src/lib/nodered-storage.spec.ts
@@ -334,4 +334,12 @@ describe('lib/nodered-storage', () => {
             }
         }, 'test-store');
     });
+
+    it('should handle undefined context gracefully', async () => {
+        const nodeRedStorage = new NoderedStorage(undefined, '');
+
+        const result = await nodeRedStorage.setBatteryLevel(1, 2);
+
+        expect(result).to.equal(undefined);
+    });
 });

--- a/src/lib/nodered-storage.ts
+++ b/src/lib/nodered-storage.ts
@@ -9,13 +9,13 @@ type Nodes = {
 export class NoderedStorage implements IStorage {
 
     constructor(
-        private context: NodeContextData,
+        private context: NodeContextData | undefined,
         private storageKey: string,
         private store = 'default'
     ) { }
 
     private async getNodes(): Promise<Nodes> {
-        const data = await this.context.get(this.storageKey, this.store);
+        const data = await this.context?.get(this.storageKey, this.store);
 
         return (data || {}) as Nodes;
     }
@@ -40,7 +40,7 @@ export class NoderedStorage implements IStorage {
             ...data
         };
 
-        return this.context.set(this.storageKey, nodes, this.store);
+        return this.context?.set(this.storageKey, nodes, this.store);
     }
 
     private async setChild(nodeId: number, childId: number, data: Partial<ISensorData>) {


### PR DESCRIPTION
When upgrading from old version, the db configuration node might be wrong, which results in an unknown context.